### PR TITLE
Fix security groups

### DIFF
--- a/templates/overcloud-node.yaml
+++ b/templates/overcloud-node.yaml
@@ -18,6 +18,16 @@ parameters:
     type: string
 
 resources:
+  overcloud_sg:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      name: overcloud_sg
+      description: Ping and SSH
+      rules:
+      - protocol: icmp
+      - protocol: tcp
+        port_range_min: 22
+        port_range_max: 22
 
   overcloud_node:
     type: OS::Nova::Server
@@ -29,6 +39,9 @@ resources:
       user_data_format: SOFTWARE_CONFIG
       networks:
         - {network: {get_param: private_net}}
+      security_groups:
+        - "default"
+        - {get_resource: overcloud_sg}
       name: {get_param: overcloud_name}
       software_config_transport: POLL_SERVER_HEAT
 

--- a/templates/undercloud.yaml
+++ b/templates/undercloud.yaml
@@ -36,6 +36,9 @@ resources:
       key_name: {get_param: key_name}
       networks:
       - network: {get_param: private_net}
+      security_groups:
+        - "default"
+        - {get_resource: undercloud_sg}
       name: {get_param: undercloud_name}
       user_data_format: SOFTWARE_CONFIG
       user_data: {get_param: undercloud_user_data}


### PR DESCRIPTION
Add a sec group for overcloud.
Use the defined security groups for under/overcloud nodes

Signed-off-by: Bogdan Dobrelya <bogdando@mail.ru>