### PR TITLE
Allow custom docker registry for toci job

### DIFF
--- a/templates/example-environments/rdo-cloud-env.yaml
+++ b/templates/example-environments/rdo-cloud-env.yaml
@@ -7,4 +7,5 @@ parameters:
   public_net:  38.145.32.0/22
   undercloud_image: CentOS-7-x86_64-GenericCloud-1703
   undercloud_flavor: m1.large
+  undercloud_docker_registry_mirror: http://mirror.regionone.tripleo-test-cloud-rh1.openstack.org:8081/registry-1.docker
   toci_jobtype: multinode-1ctlr-featureset004

--- a/templates/toci-job.yaml
+++ b/templates/toci-job.yaml
@@ -40,6 +40,11 @@ parameters:
                  this build is dependent upon in the form of a colon character separated
                  list consisting of project name, target branch, and revision ref.
 
+  undercloud_docker_registry_mirror:
+    type: string
+    default: ""
+    description: A docker registry mirror
+
 resources:
 
   TociJobUndercloudConfig:
@@ -56,6 +61,7 @@ resources:
         echo export ZUUL_CHANGES=\"$ZUUL_CHANGES\" >> /etc/profile.d/traas.sh
         echo export TRIPLEO_CI_REMOTE=\"$TRIPLEO_CI_REMOTE\" >> /etc/profile.d/traas.sh
         echo export TRIPLEO_CI_BRANCH=\"$TRIPLEO_CI_BRANCH\" >> /etc/profile.d/traas.sh
+        echo export NODEPOOL_DOCKER_REGISTRY_PROXY=\"$NODEPOOL_DOCKER_REGISTRY_PROXY\" >> /etc/profile.d/traas.sh
         mkdir -p /etc/nodepool
         if [ ! -f /etc/nodepool/id_rsa ]; then
           ssh-keygen -t rsa -f /etc/nodepool/id_rsa
@@ -84,6 +90,9 @@ resources:
         - name: TRIPLEO_CI_BRANCH
           type: String
           description: Git branch to use for tripleo-ci repository
+        - name: NODEPOOL_DOCKER_REGISTRY_PROXY
+          type: String
+          description: A docker registry proxy
       outputs:
         - name: public_key
           description: public key
@@ -104,6 +113,7 @@ resources:
         TOCI_JOBTYPE: {get_param: toci_jobtype}
         TRIPLEO_CI_REMOTE: {get_param: tripleo_ci_remote}
         TRIPLEO_CI_BRANCH: {get_param: tripleo_ci_branch}
+        NODEPOOL_DOCKER_REGISTRY_PROXY: {get_param: undercloud_docker_registry_mirror}
 
   DisconnectFromHostHeat:
     type: OS::Heat::Value
@@ -199,6 +209,9 @@ resources:
         - name: TRIPLEO_CI_BRANCH
           type: String
           description: Git branch to use for tripleo-ci repository
+        - name: NODEPOOL_DOCKER_REGISTRY_PROXY
+          type: String
+          description: A docker registry proxy
 
   TociJobDeployment:
     type: OS::Heat::SoftwareDeployment

--- a/templates/traas.yaml
+++ b/templates/traas.yaml
@@ -54,6 +54,11 @@ parameters:
     default: CentOS-7-x86_64-GenericCloud-1503
     description: Image to boot as the undercloud instance
 
+  undercloud_docker_registry_mirror:
+    type: string
+    default: ""
+    description: A docker registry mirror
+
   toci_jobtype:
     type: string
     default: multinode-nonha-oooq
@@ -144,6 +149,7 @@ resources:
     properties:
       undercloud: {get_attr: [undercloud, undercloud_server]}
       undercloud_private_ip: {get_attr: [undercloud, undercloud_private_ip]}
+      undercloud_docker_registry_mirror: {get_param: undercloud_docker_registry_mirror}
       overcloud_nodes: {get_attr: [overcloud_nodes, resource.overcloud_nodes, attributes, overcloud_node]}
       overcloud_private_ips: {get_attr: [overcloud_nodes, resource.overcloud_nodes, overcloud_private_ip]}
       toci_jobtype: {get_param: toci_jobtype}


### PR DESCRIPTION
Cover containerized deployments from custom
docker registries. Set defaults for an example template
as upstream CI jobs uses.

Signed-off-by: Bogdan Dobrelya <bogdando@mail.ru>