### PR TITLE
Load docker images from a volume, update user_data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,18 @@ The Heat templates are used to bring up a multinode environment, and then
 trigger some SoftwareDeployment resources on the undercloud node to
 execute a tripleo-ci job.
 
+Here are example commands to use it::
+
+  $ mkvirtualenv ocata
+  $ wget https://raw.githubusercontent.com/openstack/requirements/stable/ocata/upper-constraints.txt -O /tmp/ocata
+  $ pip install -c /tmp/ocata python-openstackclient python-heatclient
+  $ git clone https://github.com/slagle/traas.git
+  $ openstack --os-cloud rdo-cloud stack create foo \
+  -t traas/templates/traas.yaml \
+  -e traas/templates/traas-resource-registry.yaml \
+  -e traas/templates/example-environments/rdo-cloud-env.yaml \
+  --wait
+
 The main template is::
 
 	 templates/traas.yaml
@@ -36,3 +48,34 @@ default nonha multinode job used upstream in tripleo-ci.
 
 It executes the ci job end to end and then leaves the environment up at the end
 for inspection and/or development.
+
+You may as well pre-create a volume and save docker images for future use.
+Define the ``volume_id`` to ensure the pre-created volume is mounted for
+an undercloud node. Then, from that undercloud node containing docker images
+(see the `overcloud-prep-containers` quickstart-extras role for details),
+do a one time export steps, for example::
+
+  # mkfs.ext4 -F /dev/vdb
+  # echo "/dev/vdb /mnt/docker_images ext4 defaults 0 0" >> /etc/fstab
+  # mkdir -p /mnt/docker_images
+  # mount -a
+  # docker save $(docker images -f dangling=false | \
+  awk '/^docker\.io/ {print $1}' | sort -u) | gzip -6 \
+  > /mnt/docker_images/tripleoupstream.tar
+  # sync
+  # umount /mnt/docker_images
+
+From now on, consequent stacks will load the saved images from the given
+``volume_id`` while running the undercloud cloud-init user script.
+
+.. note:: Changing docker graph driver or remapping its userns will reset
+  loaded docker images.
+
+For overcloud nodes to access loaded images from a local registry, configure
+the registry for the undercloud node, like this::
+
+  # docker pull registry
+  # docker run -dit -p 8787:5000 --name registry registry
+  # curl -s <ctl_plane_ip>:8787/v2/_catalog | python -mjson.tool
+
+There the `ctl_plane_ip` comes from the wanted quickstart-extras variables.

--- a/templates/example-environments/rdo-cloud-env.yaml
+++ b/templates/example-environments/rdo-cloud-env.yaml
@@ -8,3 +8,4 @@ parameters:
   undercloud_image: CentOS-7-x86_64-GenericCloud-1703
   undercloud_flavor: m1.large
   toci_jobtype: multinode-1ctlr-featureset004
+  volume_id: null

--- a/templates/traas.yaml
+++ b/templates/traas.yaml
@@ -54,6 +54,11 @@ parameters:
     default: CentOS-7-x86_64-GenericCloud-1503
     description: Image to boot as the undercloud instance
 
+  volume_id:
+    description: An external volume ID for docker images
+    default: null
+    type: string
+
   toci_jobtype:
     type: string
     default: multinode-nonha-oooq
@@ -95,15 +100,40 @@ resources:
       type: string
       value: |
         #!/bin/bash
+        # Ensure dev requirements for pre-provisioned nodes
+        setenforce 0
+        sed -i 's/^SELINUX=.*/SELINUX=permissive/' /etc/selinux/config
         rpm -q git || yum -y install git
         git clone https://git.openstack.org/openstack-infra/tripleo-ci
         export HOME=/root
         tripleo-ci/scripts/tripleo.sh --repo-setup
+        # a few restoration spells from tripleo-ci scripts
+        rm -rf /usr/lib/python2.7/site-packages/requests/ /usr/lib/python2.7/site-packages/urllib3
+        rpm -e --nodeps python-requests python-urllib3 || :
+        rpm -e --nodeps python2-requests python2-urllib3 || :
+        yum -y install python-requests python-urllib3
+        # configure os-collect-config to enable heat to do its things
         yum -y install python-heat-agent*
         rm -f /etc/yum.repos.d/delorean*
         rm -rf tripleo-ci
         systemctl daemon-reload
         systemctl enable os-collect-config
+        # paunch is not packaged yet
+        pip install paunch>=1.0.0
+        # Overlay2 for docker
+        cat > /etc/sysconfig/docker-storage <<-EOF_CAT
+        DOCKER_STORAGE_OPTIONS=-s overlay2
+        EOF_CAT
+        systemctl enable docker
+        # Load docker images from the mounted volume_id -> /dev/vdb
+        [ -e /dev/vdb ] || (sync; reboot)
+        systemctl start docker
+        echo "/dev/vdb /mnt/docker_images ext4 defaults 0 0" >> /etc/fstab
+        mkdir -p /mnt/docker_images
+        mount -a
+        [ -f /mnt/docker_images/tripleoupstream.tar ] && \
+        docker load -i /mnt/docker_images/tripleoupstream.tar
+        sync
         reboot
 
   undercloud:
@@ -113,6 +143,7 @@ resources:
       undercloud_flavor: {get_param: undercloud_flavor}
       undercloud_image: {get_param: undercloud_image}
       key_name: {get_param: key_name}
+      volume_id: {get_param: volume_id}
       undercloud_name:
         list_join:
           - '-'

--- a/templates/undercloud.yaml
+++ b/templates/undercloud.yaml
@@ -15,6 +15,8 @@ parameters:
     type: string
   public_net:
     type: string
+  volume_id:
+    type: string
 
 resources:
   undercloud_sg:
@@ -43,6 +45,12 @@ resources:
       user_data_format: SOFTWARE_CONFIG
       user_data: {get_param: undercloud_user_data}
       software_config_transport: POLL_SERVER_HEAT
+
+  persistent_volume:
+    type: OS::Cinder::VolumeAttachment
+    properties:
+      instance_uuid: {get_resource: undercloud_server}
+      volume_id: {get_param: volume_id}
 
   undercloud_floating_ip:
     type: OS::TraaS::UndercloudFloating


### PR DESCRIPTION
Allow manually saved docker images to be loaded from
an external volume_id at the cloud-init stage.
Naively attempt to load them from a hardocded
/mnt/docker_images/tripleoupstream.tar path from the
/dev/vdb device automagically.

Update user data script with:
* Docker overlay2.
* Recent tripleo-ci requests/urllib magic fixes.
* Pip install paunch>=1.0.0 from global reqs.
* Disable selinux.

Add simple docs for README.

Signed-off-by: Bogdan Dobrelya <bogdando@mail.ru>