### PR TITLE
Setup unbound in setup-host-cloud-os-collect-config

### DIFF
--- a/templates/traas.yaml
+++ b/templates/traas.yaml
@@ -104,6 +104,9 @@ resources:
         rm -rf tripleo-ci
         systemctl daemon-reload
         systemctl enable os-collect-config
+        # unbound is required to have local resolver
+        yum install -y unbound
+        systemctl enable unbound
         reboot
 
   undercloud:


### PR DESCRIPTION
unbound is now required by TripleO CI to use local resolver instead of
external servers like before.