### PR TITLE
Adding traas_repository and stable_release variables

### DIFF
--- a/scripts/traas.sh
+++ b/scripts/traas.sh
@@ -23,6 +23,8 @@ export ZUUL_CHANGES=${ZUUL_CHANGES:-""}
 export TRIPLEO_CI_REMOTE=${TRIPLEO_CI_REMOTE:-https://github.com/slagle/tripleo-ci}
 export TRIPLEO_CI_BRANCH=${TRIPLEO_CI_BRANCH:-traas}
 export EXTRA_VARS=${EXTRA_VARS:-""}
+export STABLE_RELEASE=${STABLE_RELEASE:-"master"}
+
 EXTRA_VARS="$EXTRA_VARS --extra-vars vxlan_mtu=1400"
 
 

--- a/templates/toci-job.yaml
+++ b/templates/toci-job.yaml
@@ -39,6 +39,15 @@ parameters:
     description: A caret character separated list of the changes upon which
                  this build is dependent upon in the form of a colon character separated
                  list consisting of project name, target branch, and revision ref.
+  traas_repository:
+    type: string
+    default: 'https://github.com/slagle/traas'
+    description: Traas git repository
+
+  stable_release:
+    type: string
+    default: 'master'
+    description: Release to be used by quickstart --release option
 
 resources:
 
@@ -56,6 +65,7 @@ resources:
         echo export ZUUL_CHANGES=\"$ZUUL_CHANGES\" >> /etc/profile.d/traas.sh
         echo export TRIPLEO_CI_REMOTE=\"$TRIPLEO_CI_REMOTE\" >> /etc/profile.d/traas.sh
         echo export TRIPLEO_CI_BRANCH=\"$TRIPLEO_CI_BRANCH\" >> /etc/profile.d/traas.sh
+        echo export STABLE_RELEASE=\"$STABLE_RELEASE\" >> /etc/profile.d/traas.sh
         mkdir -p /etc/nodepool
         if [ ! -f /etc/nodepool/id_rsa ]; then
           ssh-keygen -t rsa -f /etc/nodepool/id_rsa
@@ -84,6 +94,10 @@ resources:
         - name: TRIPLEO_CI_BRANCH
           type: String
           description: Git branch to use for tripleo-ci repository
+        - name: STABLE_RELEASE
+          type: String
+          description: Release to be used by quickstart --release option
+
       outputs:
         - name: public_key
           description: public key
@@ -105,6 +119,7 @@ resources:
         TRIPLEO_CI_REMOTE: {get_param: tripleo_ci_remote}
         TRIPLEO_CI_BRANCH: {get_param: tripleo_ci_branch}
         ZUUL_CHANGES: {get_param: zuul_changes}
+        STABLE_RELEASE: {get_param: stable_release}
 
   DisconnectFromHostHeat:
     type: OS::Heat::Value
@@ -171,7 +186,7 @@ resources:
             $disconnect_snippet
 
             rpm -q git || yum -y install git
-            su -l centos -c "git clone https://github.com/slagle/traas"
+            su -l centos -c "git clone $traas_repository"
             su -l centos -c /home/centos/traas/scripts/traas.sh &
 
             # This is pretty hacky, meh.
@@ -181,6 +196,7 @@ resources:
             exit 0
           params:
             $disconnect_snippet: {get_attr: [DisconnectFromHostHeat, value]}
+            $traas_repository: {get_param: traas_repository}
       inputs:
         - name: PRIMARY_NODE_IP
           type: String
@@ -200,6 +216,9 @@ resources:
         - name: TRIPLEO_CI_BRANCH
           type: String
           description: Git branch to use for tripleo-ci repository
+        - name: STABLE_RELEASE
+          type: String
+          description: Branch to be used by quickstart --release option
 
   TociJobDeployment:
     type: OS::Heat::SoftwareDeployment
@@ -216,6 +235,7 @@ resources:
         TOCI_JOBTYPE: {get_param: toci_jobtype}
         TRIPLEO_CI_REMOTE: {get_param: tripleo_ci_remote}
         TRIPLEO_CI_BRANCH: {get_param: tripleo_ci_branch}
+        STABLE_RELEASE: {get_param: stable_release}
       signal_transport: NO_SIGNAL
 
 outputs:

--- a/templates/traas.yaml
+++ b/templates/traas.yaml
@@ -76,6 +76,16 @@ parameters:
     default: traas
     description: Git branch to use for tripleo-ci repository
 
+  traas_repository:
+    type: string
+    default: 'https://github.com/slagle/traas'
+    description: Traas git repository
+
+  stable_release:
+    type: string
+    default: master
+    description: Release to be used by --release quickstart option
+
 
 resources:
 
@@ -153,5 +163,7 @@ resources:
       zuul_changes: {get_param: zuul_changes}
       tripleo_ci_remote: {get_param: tripleo_ci_remote}
       tripleo_ci_branch: {get_param: tripleo_ci_branch}
+      stable_release: {get_param: stable_release}
+      traas_repository: {get_param: traas_repository}
 
 outputs:


### PR DESCRIPTION
The stable_release variable will allow traas to execute other
than master releases, as for example the tripleo-ci-testing
and traas_repository will allow traas to clone from other
repos than the default one, in case you have a custom traas.sh
script