### PR TITLE
Switch to upstream tripleo-ci repo

### DIFF
--- a/templates/toci-job.yaml
+++ b/templates/toci-job.yaml
@@ -25,12 +25,12 @@ parameters:
 
   tripleo_ci_remote:
     type: string
-    default: "https://github.com/slagle/tripleo-ci"
+    default: "https://git.openstack.org/cgit/openstack-infra/tripleo-ci"
     description: Git remote to use for tripleo-ci repository
 
   tripleo_ci_branch:
     type: string
-    default: traas
+    default: master
     description: Git branch to use for tripleo-ci repository
 
   ci_changes:

--- a/templates/traas.yaml
+++ b/templates/traas.yaml
@@ -89,12 +89,12 @@ parameters:
 
   tripleo_ci_remote:
     type: string
-    default: "https://github.com/slagle/tripleo-ci"
+    default: "https://git.openstack.org/cgit/openstack-infra/tripleo-ci"
     description: Git remote to use for tripleo-ci repository
 
   tripleo_ci_branch:
     type: string
-    default: traas
+    default: master
     description: Git branch to use for tripleo-ci repository
 
   traas_repository:


### PR DESCRIPTION
It seems we can safely use the upstream tripleo CI repo.
The diff to the fork (after rebase done) seems a minimal and almost cosmetic, see
https://github.com/slagle/tripleo-ci/pull/1#issuecomment-360149801

Signed-off-by: Bogdan Dobrelya <bogdando@mail.ru>