### PR TITLE
Fix tripleo-ci git

### DIFF
--- a/templates/toci-job.yaml
+++ b/templates/toci-job.yaml
@@ -25,7 +25,7 @@ parameters:
 
   tripleo_ci_remote:
     type: string
-    default: "https://git.openstack.org/cgit/openstack-infra/tripleo-ci"
+    default: "https://git.openstack.org/openstack-infra/tripleo-ci"
     description: Git remote to use for tripleo-ci repository
 
   tripleo_ci_branch:

--- a/templates/traas.yaml
+++ b/templates/traas.yaml
@@ -89,7 +89,7 @@ parameters:
 
   tripleo_ci_remote:
     type: string
-    default: "https://git.openstack.org/cgit/openstack-infra/tripleo-ci"
+    default: "https://git.openstack.org/openstack-infra/tripleo-ci"
     description: Git remote to use for tripleo-ci repository
 
   tripleo_ci_branch:


### PR DESCRIPTION
URL was wrong and was leading to:
fatal: repository 'https://git.openstack.org/cgit/openstack-infra/tripleo-ci/' not found