### PR TITLE
Document ci_changes

### DIFF
--- a/templates/toci-job.yaml
+++ b/templates/toci-job.yaml
@@ -37,7 +37,8 @@ parameters:
     type: string
     default: ''
     description: A caret character separated list of the changes upon which
-                 tripleo-ci, tripleo-quickstart, tripleo-quickstart-extra
+                 tripleo-ci, tripleo-quickstart, tripleo-quickstart-extra.
+                 Can be 'openstack/tripleo-quickstart:343433^openstack/tripleo-quickstart-extras:737343'
 
   zuul_changes:
     type: string

--- a/templates/traas.yaml
+++ b/templates/traas.yaml
@@ -85,7 +85,8 @@ parameters:
     type: string
     default: ''
     description: A caret character separated list of the changes upon which
-                 tripleo-ci, tripleo-quickstart, tripleo-quickstart-extra
+                 tripleo-ci, tripleo-quickstart, tripleo-quickstart-extra.
+                 Can be 'openstack/tripleo-quickstart:343433^openstack/tripleo-quickstart-extras:737343'
 
   tripleo_ci_remote:
     type: string


### PR DESCRIPTION
ci_changes somehow replaces zuul_changes for TripleO CI repos. It's not
obvious for previous users, so we need to document the new parameter and
the format (that also changed).